### PR TITLE
Dev

### DIFF
--- a/db_parser.py
+++ b/db_parser.py
@@ -84,18 +84,23 @@ class DB_Parser():
         self.client = MongoClient('mongodb://{}:{}/'.format(mongo_ip, mongo_port))
         self.swaps = self.client.swaps
 
+        if self.parsed_files:
+            self.parsed = self.swaps.parsed_files
+
         self.is_fresh_run = not bool(self.swaps.list_collection_names())
-        self.parsed_files_list = []
+        if self.is_fresh_run:
+            self.parsed_files_list = []
+        else:
+            self.parsed_files_list = list(self.parsed.find({'data': {'$exists': 'true', '$ne': []}}))[0]['data']
+            print(type(self.parsed_files_list))
+            print(self.parsed_files_list)
 
         #creating main successful/failed collections
         if self.save_failed:
             self.failed = self.swaps.failed_swaps_collection
 
         if self.save_successful:
-            self.successful = self.swaps.successsful_swaps_collection
-
-        if self.parsed_files:
-            self.parsed = self.swaps.parsed_files
+            self.successful = self.swaps.successful_swaps_collection
 
 
         '''
@@ -297,7 +302,8 @@ class DB_Parser():
     '''
     @measure
     def insert_into_parsed_files_collection(self):
-        self.parsed.insert({'data' : self.parsed_files_list})
+        self.parsed.update_one({'data': {'$exists': 'true', '$ne': []}},
+                               {'$addToSet': {'data': {'$each': self.parsed_files_list}}}, upsert=True)
 
 
     @measure
@@ -313,19 +319,23 @@ class DB_Parser():
         #commented out for now since takes too much time
         #self.insert_into_traiding_pair_collection(raw_swap_data)
         #self.insert_into_uuid_collection(raw_swap_data)
-
-        if swap_successful:
-            if self.is_swap_finished(swap_events):
-                self.successful.insert(raw_swap_data)
+        if not (raw_swap_data.get('uuid') in self.parsed_files_list):
+            if swap_successful:
+                if self.is_swap_finished(swap_events):
+                    self.successful.insert(raw_swap_data)
+                    self.parsed_files_list.append(raw_swap_data.get('uuid'))
+                    logging.debug('Insertion into collection: DONE')
+                    return True
+                else:
+                    logging.debug('Insertion into collection: ABORTED - Ongoing swap')
+                    return False
             else:
-                logging.debug('Insertion into collection: ABORTED - Ongoing swap')
-                return False
-        else:
-            self.failed.insert(raw_swap_data)
-
-
-        logging.debug('Insertion into collection: DONE')
-        return True
+                self.failed.insert(raw_swap_data)
+                self.parsed_files_list.append(raw_swap_data.get('uuid'))
+                logging.debug('Insertion into collection: DONE')
+                return True
+        logging.debug('Insertion into collection: ABORTED -- Existing swap')
+        return False
         '''
         elif not self.is_fresh_run and is_swap_successful:
             self.successful.update({"uuid": raw_swap_data["uuid"]}, raw_swap_data, upsert=True)

--- a/db_parser.py
+++ b/db_parser.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-from gevent import monkey
-_ = monkey.patch_all()
+# from gevent import monkey
+# _ = monkey.patch_all()
 
 
 from utils.swap_events import (maker_swap_success_events,

--- a/db_parser.py
+++ b/db_parser.py
@@ -298,10 +298,10 @@ class DB_Parser():
     @measure
     def insert_into_parsed_files_collection(self):
         self.parsed.insert({'data' : self.parsed_files_list})
-    
+
 
     @measure
-    def insert_into_swap_collection(self, swap_file : str):
+    def insert_into_swap_collection(self, swap_file : str) -> bool:
         logging.debug('\n\nInsertion into collection:'
                       '\n  reading swap file {}'.format(swap_file))
         raw_swap_data = self.parse_swap_data(swap_file)
@@ -315,13 +315,17 @@ class DB_Parser():
         #self.insert_into_uuid_collection(raw_swap_data)
 
         if swap_successful:
-            self.successful.insert(raw_swap_data)
+            if self.is_swap_finished(swap_events):
+                self.successful.insert(raw_swap_data)
+            else:
+                logging.debug('Insertion into collection: ABORTED - Ongoing swap')
+                return False
         else:
             self.failed.insert(raw_swap_data)
 
 
         logging.debug('Insertion into collection: DONE')
-
+        return True
         '''
         elif not self.is_fresh_run and is_swap_successful:
             self.successful.update({"uuid": raw_swap_data["uuid"]}, raw_swap_data, upsert=True)

--- a/pymongo_observer.py
+++ b/pymongo_observer.py
@@ -46,13 +46,11 @@ class SwapsObserver(Observer):
 def on_created(event):
     if ".json" in event.src_path:
         Parser.insert_into_swap_collection(event.src_path)
-    print(event.src_path)
 
 
 def on_modified(event):
     if ".json" in event.src_path:
         Parser.insert_into_swap_collection(event.src_path)
-    print(event.src_path)
 
 
 if __name__ == "__main__":

--- a/pymongo_observer.py
+++ b/pymongo_observer.py
@@ -23,12 +23,11 @@ class SwapsObserver(Observer):
         else:
             pre_snap = EmptyDirectorySnapshot()
 
-        for watcher, handler in self._handlers.items():
-            self.path = watcher.path
+        for watcher, handler in self._handlers.items():  # dict { watcher: handler }
+            self.path = watcher.path  # we have single watcher: handler item, thus it works
             curr_snap = DirectorySnapshot(path)
             diff = DirectorySnapshotDiff(pre_snap, curr_snap)
             for h in handler:
-                # Dispatch files modifications
                 for new_path in diff.files_created:
                     if self.mask in new_path:
                         h.dispatch(FileCreatedEvent(new_path))

--- a/pymongo_observer.py
+++ b/pymongo_observer.py
@@ -73,3 +73,4 @@ if __name__ == "__main__":
     except KeyboardInterrupt:
         observer.stop()
     observer.join()
+    Parser.insert_into_parsed_files_collection()

--- a/pymongo_observer.py
+++ b/pymongo_observer.py
@@ -1,0 +1,65 @@
+import time
+import os
+import pickle
+from watchdog.observers import Observer
+from watchdog.events import PatternMatchingEventHandler
+from watchdog.utils import dirsnapshot
+
+
+def on_created(event):
+    # pass to db_parser
+    print(event.src_path)
+
+
+def on_modified(event):
+    # pass to db_parser
+    print(event.src_path)
+
+
+def make_snapshot(dpath):
+    with open('snap_latest', 'wb') as sf:
+        snap_latest = dirsnapshot.DirectorySnapshot(dpath, recursive=True)
+        print(repr(snap_latest))
+        pickle.dump(snap_latest, sf, -1)
+
+
+def check_snapshot(dpath, old_snap_exists=True):
+    snap_current = dirsnapshot.DirectorySnapshot(dpath, recursive=True)
+    snap_prev = {}
+    if old_snap_exists:
+        with open('snap_latest', 'rb') as sg:
+            snap_prev = pickle.load(sg)
+    else:
+        snap_prev = dirsnapshot.EmptyDirectorySnapshot()
+    check = dirsnapshot.DirectorySnapshotDiff(snap_prev, snap_current)
+
+    for mods in check.files_modified:
+        print(mods)     # pass to db_parser
+    for new in check.files_created:
+        print(new)      # pass to db_parser
+
+
+if __name__ == "__main__":
+    patterns = "*.json"
+    ignore_patterns = ""
+    ignore_directories = False
+    case_sensitive = True
+    my_event_handler = PatternMatchingEventHandler(patterns, ignore_patterns, ignore_directories, case_sensitive)
+    my_event_handler.on_created = on_created
+    my_event_handler.on_modified = on_modified
+    path = "../SWAPS/STATS/MAKER/"
+    go_recursively = True
+    my_observer = Observer()
+    my_observer.schedule(my_event_handler, path, recursive=go_recursively)
+    my_observer.start()
+    snapshot_found = False
+    if os.path.isfile('snap_latest'):
+        snapshot_found = True
+    check_snapshot(path, snapshot_found)
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        my_observer.stop()
+        my_observer.join()
+    make_snapshot(path)


### PR DESCRIPTION
added watchdog to monitor swaps directory
fixed parsed_files_list and it's behavior

NOTE: commented out
```
# from gevent import monkey
# _ = monkey.patch_all()
```
watchdog is asynchronous by default and uses gevent, monkey patching db_parser breaks it.

Now `python3 pymongo_observer.py` starts parser and correctly fills database in real time, no need for crontab.